### PR TITLE
feat(File UI): Cleaned up the main directory page

### DIFF
--- a/FileLink.Client/FileOperations/FileSelector.cs
+++ b/FileLink.Client/FileOperations/FileSelector.cs
@@ -96,6 +96,9 @@ public class FileSelector : INotifyPropertyChanged
                 var result = await _fileService.UploadFileAsync(file.fullPath, null, userId);
                 if (result != null)
                 {
+                    // This should remove the files as there sent but theres a bug where the click to send only send 1
+                    // it works whenever you send the file those so its low priority 
+                    //RemoveFile(file);
                     Console.WriteLine($"File uploaded successfully: {file.fileName}");
                 }
                 else

--- a/FileLink.Client/FileOperations/FileSelector.cs
+++ b/FileLink.Client/FileOperations/FileSelector.cs
@@ -3,6 +3,8 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Windows.Input;
 using FileLink.Client.Services;
+using System.Threading;
+using FileLink.Client.DirectoryNavigation;
 
 namespace FileLink.Client.FileOperations;
 
@@ -81,7 +83,7 @@ public class FileSelector : INotifyPropertyChanged
             Console.WriteLine("Error Sending File: Not authenticated. Please log in first.");
             return;
         }
-
+        
         string userId = _authService.CurrentUser?.Id;
         if (string.IsNullOrEmpty(userId))
         {
@@ -98,7 +100,7 @@ public class FileSelector : INotifyPropertyChanged
                 {
                     // This should remove the files as there sent but theres a bug where the click to send only send 1
                     // it works whenever you send the file those so its low priority 
-                    //RemoveFile(file);
+                    RemoveFile(file);
                     Console.WriteLine($"File uploaded successfully: {file.fileName}");
                 }
                 else
@@ -111,6 +113,9 @@ public class FileSelector : INotifyPropertyChanged
                 Console.WriteLine($"Error Sending File: {ex.Message}");
             }
         }
+        
+        // Would be useful to be able to call the LoadCurrentDirectory after adding files 
+        // but im not sure how you'd like to go about that 
     }
     
     // Updates the boolean based on Files count

--- a/FileLink.Client/MainViewModel.cs
+++ b/FileLink.Client/MainViewModel.cs
@@ -6,8 +6,8 @@ namespace FileLink.Client;
 
 // This class is used to have all of our view models viewable as data contexts
 public class MainViewModel
-{
-    public FileSelector FileVM { get; set; }
+{ 
+    public FileSelector FileSelectorVM { get; set; }
     public DirectoryMap DirectoryVM { get; set; }
     
     // Take services as parameters instead of creating new instances
@@ -17,7 +17,7 @@ public class MainViewModel
         DirectoryService directoryService)
     {
         // Initialize with the authenticated services
-        FileVM = new FileSelector(fileService, authService);
+        FileSelectorVM = new FileSelector(fileService, authService);
         
         // Initialize directory navigation with the right service
         // This will need to be updated to use DirectoryService too

--- a/FileLink.Client/Pages/MainPage.xaml
+++ b/FileLink.Client/Pages/MainPage.xaml
@@ -117,172 +117,82 @@
                     IsVisible="False" />
             </VerticalStackLayout>
         </Grid>
-        
         <!-- ========== MAIN CONTENT AREA ========== -->
-        <ScrollView Grid.Column="1" Padding="20">
-            <VerticalStackLayout Spacing="20">
-
-                <!-- Search Bar -->
-                <SearchBar Placeholder="Search..."
-                           BackgroundColor="White"
-                           HeightRequest="40"/>
-                           
-                <!--
-                
-                <Label Text="Categories"
+        <Grid Grid.Column="1" Padding="20">
+    <!-- Non-scrolling content (Search Bar and Directory Tab) -->
+    <Grid RowDefinitions="Auto, *">
+        
+        <VerticalStackLayout Grid.Row="0">
+        <!-- Search Bar (not inside ScrollView) -->
+            <SearchBar Placeholder="Search..."
+                       BackgroundColor="White"
+                       HeightRequest="40"/>
+            
+            <!-- Directory Tab and Back Button (not inside ScrollView) -->
+            <Grid ColumnDefinitions="Auto, *, Auto" Padding="20">
+                <Label Text="Directories"
+                       Grid.Column="0"
+                       FontSize="26"
                        FontAttributes="Bold"
-                       FontSize="16"
                        TextColor="#333"/>
-                
-                <HorizontalStackLayout Spacing="10">
-                    <Frame CornerRadius="6"
-                           WidthRequest="120"
-                           HeightRequest="110"
-                           BackgroundColor="#7B6FBE"
-                           Padding="10">
-                        <VerticalStackLayout>
-                            <Label Text="Documents" 
-                                   TextColor="#E8F0FF"
-                                   FontAttributes="Bold"
-                                   FontSize="14"/>
-                            <Label Text="456 Files" 
-                                   TextColor="#E8F0FF"
-                                   FontSize="12"/>
-                        </VerticalStackLayout>
-                    </Frame>
+                <BoxView BackgroundColor="Transparent" Grid.Column="1"/>
+                <Button Text="BACK"
+                        Command="{Binding DirectoryVM.backButtonCommand}"
+                        IsVisible="{Binding DirectoryVM.IsButtonVisible}"
+                        Grid.Column="2"/>
+            </Grid>
 
-                    <Frame CornerRadius="6"
-                           WidthRequest="120"
-                           HeightRequest="110"
-                           BackgroundColor="#BE6F6F"
-                           Padding="10">
-                        <VerticalStackLayout>
-                            <Label Text="Pictures" 
-                                   TextColor="#E8F0FF"
-                                   FontAttributes="Bold"
-                                   FontSize="14"/>
-                            <Label Text="201 Files" 
-                                   TextColor="#E8F0FF"
-                                   FontSize="12"/>
-                        </VerticalStackLayout>
-                    </Frame>
+    </VerticalStackLayout>
 
-                    <Frame CornerRadius="6"
-                           WidthRequest="120"
-                           HeightRequest="110"
-                           BackgroundColor="#6FB6BE"
-                           Padding="10">
-                        <VerticalStackLayout>
-                            <Label Text="Videos" 
-                                   TextColor="#E8F0FF"
+    <!-- Scrollable Content -->
+    <ScrollView Grid.Row="1">
+        <VerticalStackLayout Spacing="20" Padding="20">
+            <!-- CollectionView for Files (this part scrolls) -->
+            <CollectionView ItemsSource="{Binding DirectoryVM.Files}" VerticalScrollBarVisibility="Always">
+                <CollectionView.ItemsLayout>
+                    <GridItemsLayout Orientation="Vertical"
+                                     HorizontalItemSpacing="5"
+                                     VerticalItemSpacing="5">
+                        <GridItemsLayout.Span>
+                            <OnIdiom x:TypeArguments="x:Int32">
+                                <OnIdiom.Phone>5</OnIdiom.Phone>
+                                <OnIdiom.Tablet>4</OnIdiom.Tablet>
+                                <OnIdiom.Desktop>5</OnIdiom.Desktop>
+                            </OnIdiom>
+                        </GridItemsLayout.Span>
+                    </GridItemsLayout>
+                </CollectionView.ItemsLayout>
+                <CollectionView.ItemTemplate>
+                    <DataTemplate x:DataType="{x:Type directoryNav:ShownFiles}">
+                        <VerticalStackLayout HorizontalOptions="Center"
+                                             VerticalOptions="Center">
+                            <!-- Image (file/folder) -->
+                            <Image Source="{Binding pngType}"
+                                   WidthRequest="125"
+                                   HeightRequest="125"
+                                   Aspect="AspectFit">
+                                <Image.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.DirectoryVM.clickDirectoryCommand}"
+                                                          CommandParameter="{Binding .}">
+                                    </TapGestureRecognizer>
+                                </Image.GestureRecognizers>
+                            </Image>
+                            <!-- File Name -->
+                            <Label Text="{Binding fileName}" 
+                                   TextColor="Black"
                                    FontAttributes="Bold"
-                                   FontSize="14"/>
-                            <Label Text="34 Files"
-                                   TextColor="#E8F0FF"
-                                   FontSize="12"/>
+                                   FontSize="16"
+                                   HorizontalTextAlignment="Center"
+                                   LineBreakMode="TailTruncation"/>
                         </VerticalStackLayout>
-                    </Frame>
-
-                    <Frame CornerRadius="6"
-                           WidthRequest="120"
-                           HeightRequest="110"
-                           BackgroundColor="#BEAC6F"
-                           Padding="10">
-                        <VerticalStackLayout>
-                            <Label Text="School" 
-                                   TextColor="#E8F0FF"
-                                   FontAttributes="Bold"
-                                   FontSize="14"/>
-                            <Label Text="375 Files"
-                                   TextColor="#E8F0FF"
-                                   FontSize="12"/>
-                        </VerticalStackLayout>
-                    </Frame>
-                    
-                    <Frame CornerRadius="6"
-                           WidthRequest="120"
-                           HeightRequest="110"
-                           BackgroundColor="#E8F0FF"
-                           Padding="10">
-                        <VerticalStackLayout>
-                            <Label Text="Add New Category"
-                                   TextColor="#4C3B8A"
-                                   FontAttributes="Bold"
-                                   FontSize="14"/>
-                            <Label/>
-                        </VerticalStackLayout>
-                    </Frame>
-                </HorizontalStackLayout>
-                -->
-                <Grid ColumnDefinitions="Auto, *, Auto">
-                    
-                    <!-- Recent Files -->
-                    <Label Text="Directories"
-                           Grid.Column="0"
-                           FontSize="26"
-                           FontAttributes="Bold"
-                           TextColor="#333"/>
-                    
-                    <BoxView BackgroundColor="Transparent"
-                             Grid.Column="1"/>
-                    
-                    <Button Text="BACK"
-                            
-                            Command="{Binding DirectoryVM.backButtonCommand}"
-                            IsVisible="{Binding DirectoryVM.IsButtonVisible}"
-                            Grid.Column="2"
-                            />
-                </Grid>
-                <!-- 
-                    Use a CollectionView or ListView for a scrollable list of "recent files". 
-                    For brevity, here’s a simple CollectionView with static items. 
-                -->
-                <!-- CollectionView of Recent Files -->
-                <CollectionView ItemsSource="{Binding DirectoryVM.Files}"
-                                Margin="5"
-                                VerticalScrollBarVisibility="Always">
-    
-                    <!-- Ensure items are wrapped in columns -->
-                    <CollectionView.ItemsLayout>
-                        <GridItemsLayout Orientation="Horizontal"
-                                         HorizontalItemSpacing="5"
-                                         VerticalItemSpacing="5"/>
-                    </CollectionView.ItemsLayout>
-    
-                    <CollectionView.ItemTemplate>
-                        <DataTemplate x:DataType="{x:Type directoryNav:ShownFiles}">
-                            
-                                
-                                <VerticalStackLayout HorizontalOptions="Center"
-                                                     VerticalOptions="Center"
-                                                     >
-                                    <!-- Image (file/folder) -->
-                                    <Image Source="{Binding pngType}"
-                                           WidthRequest="125"
-                                           HeightRequest="125"
-                                           Aspect="AspectFit">
-                                        <Image.GestureRecognizers>
-                                            <TapGestureRecognizer Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.DirectoryVM.clickDirectoryCommand}"
-                                                                  CommandParameter="{Binding .}">
-                                            </TapGestureRecognizer>
-                                        </Image.GestureRecognizers>
-                                    </Image>
-                                    <!-- File Name -->
-                                    <Label Text="{Binding fileName}" 
-                                           TextColor="Black"
-                                           FontAttributes="Bold"
-                                           FontSize="16"
-                                           HorizontalTextAlignment="Center"
-                                           LineBreakMode="TailTruncation"/>
-                                    
-                                </VerticalStackLayout>
-                        </DataTemplate>
-                    </CollectionView.ItemTemplate>
-                </CollectionView>
-
-            </VerticalStackLayout>
-        </ScrollView>
-
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+        </VerticalStackLayout>
+        
+    </ScrollView>
+    </Grid>
+</Grid>
 
         <!-- RIGHT SIDEBAR -->
         <ScrollView Grid.Column="2" Padding="20">

--- a/FileLink.Client/Pages/MainPage.xaml
+++ b/FileLink.Client/Pages/MainPage.xaml
@@ -174,7 +174,8 @@
                                    Aspect="AspectFit">
                                 <Image.GestureRecognizers>
                                     <TapGestureRecognizer Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.DirectoryVM.clickDirectoryCommand}"
-                                                          CommandParameter="{Binding .}">
+                                                          CommandParameter="{Binding .}"
+                                                          NumberOfTapsRequired="2">
                                     </TapGestureRecognizer>
                                 </Image.GestureRecognizers>
                                 <Image.Shadow>

--- a/FileLink.Client/Pages/MainPage.xaml
+++ b/FileLink.Client/Pages/MainPage.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:clientPrototype="clr-namespace:"
              xmlns:client="clr-namespace:FileLink.Client"
-             xmlns:fileselector="clr-namespace:FileLink.Client.FileOperations"
+             xmlns:fileOperations="clr-namespace:FileLink.Client.FileOperations"
              xmlns:directoryNav="clr-namespace:FileLink.Client.DirectoryNavigation"
              Shell.NavBarIsVisible="False"
              x:Class="FileLink.Client.Pages.MainPage">
@@ -117,19 +117,21 @@
                     IsVisible="False" />
             </VerticalStackLayout>
         </Grid>
+        
         <!-- ========== MAIN CONTENT AREA ========== -->
         <Grid Grid.Column="1" Padding="20">
     <!-- Non-scrolling content (Search Bar and Directory Tab) -->
     <Grid RowDefinitions="Auto, *">
         
-        <VerticalStackLayout Grid.Row="0">
-        <!-- Search Bar (not inside ScrollView) -->
+        <VerticalStackLayout Grid.Row="0" Margin="0,20,0,0">
+        <!-- Search Bar  -->
             <SearchBar Placeholder="Search..."
                        BackgroundColor="White"
-                       HeightRequest="40"/>
+                       HeightRequest="40"
+                       />
             
-            <!-- Directory Tab and Back Button (not inside ScrollView) -->
-            <Grid ColumnDefinitions="Auto, *, Auto" Padding="20">
+            <!-- Directory Tab and Back Button -->
+            <Grid ColumnDefinitions="Auto, *, Auto" Padding="15" Margin="0,8,0,0">
                 <Label Text="Directories"
                        Grid.Column="0"
                        FontSize="26"
@@ -138,11 +140,10 @@
                 <BoxView BackgroundColor="Transparent" Grid.Column="1"/>
                 <Button Text="BACK"
                         Command="{Binding DirectoryVM.backButtonCommand}"
-                        IsVisible="{Binding DirectoryVM.IsButtonVisible}"
+                        IsVisible="{Binding DirectoryVM.IsBackButtonVisible}"
                         Grid.Column="2"/>
             </Grid>
-
-    </VerticalStackLayout>
+        </VerticalStackLayout>
 
     <!-- Scrollable Content -->
     <ScrollView Grid.Row="1">
@@ -176,6 +177,12 @@
                                                           CommandParameter="{Binding .}">
                                     </TapGestureRecognizer>
                                 </Image.GestureRecognizers>
+                                <Image.Shadow>
+                                    <Shadow Brush="Black"
+                                            Radius="15"
+                                            Opacity="0.6"
+                                            Offset="5,5"/>
+                                </Image.Shadow>
                             </Image>
                             <!-- File Name -->
                             <Label Text="{Binding fileName}" 
@@ -195,96 +202,154 @@
 </Grid>
 
         <!-- RIGHT SIDEBAR -->
-        <ScrollView Grid.Column="2" Padding="20">
-            <VerticalStackLayout Spacing="20">
+        
+        
+            <ScrollView Padding="20" Grid.Column="2">
+                
+                <Grid RowDefinitions="Auto, *, Auto">
+                    
+                    <VerticalStackLayout Grid.Row="0" Spacing="20">
+                    <!-- Add New Files -->
+                        <Frame Padding="20" CornerRadius="10" BackgroundColor="White" Margin="0,17,0,0">
+                            <VerticalStackLayout Spacing="10">
+                                <Label Text="Add New Files" 
+                                       FontAttributes="Bold"
+                                       FontSize="16"/>
+                                <Button Text="Upload" 
+                                        BackgroundColor="#4C3B8A" 
+                                        TextColor="White"
+                                        Command="{Binding FileSelectorVM.AddFilesCommand}">
+                                    <Button.Shadow>
+                                        <Shadow Brush="Black" 
+                                                Radius="10" 
+                                                Opacity="0.5" 
+                                                Offset="2,2"/>
+                                    </Button.Shadow>
+                                </Button>
+                            </VerticalStackLayout>
+                        </Frame>
+                    
+                        <Frame Padding="20" CornerRadius="10" BackgroundColor="White">
+                            <VerticalStackLayout Spacing="10">
+                                    <Label Text="Sending Queue" 
+                                           FontAttributes="Bold"
+                                           FontSize="16"
+                                           VerticalTextAlignment="Center"
+                                           Margin="0,7,0,0"
+                                           />
+                                    <BoxView Color="#4C3B8A"
+                                             HeightRequest="2"
+                                             IsVisible="{Binding FileSelectorVM.IsButtonVisible}"
+                                             Margin="0,3,0,0"/>
+                                    
+                                <CollectionView ItemsSource="{Binding FileSelectorVM.Files}">
+                                    <CollectionView.ItemTemplate>
+                                        <DataTemplate x:DataType="{x:Type fileOperations:FilesSelected}">
+                                            <Grid ColumnDefinitions="*, Auto">
+                                                    
+                                                    <Label Text="{Binding fileName}" 
+                                                           VerticalOptions="Center"
+                                                           Grid.Column="0"/> 
+                                                
+                                                    <Button Text="X"
+                                                            Style="{x:Null}"
+                                                            BackgroundColor="Transparent"
+                                                            TextColor="Black"
+                                                            BorderWidth="0"
+                                                            CornerRadius="0"
+                                                            Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.FileSelectorVM.RemoveFilesCommand}"
+                                                            CommandParameter="{Binding .}"
+                                                            Grid.Column="1"/>
+                                            </Grid>
+                                        </DataTemplate>
+                                    </CollectionView.ItemTemplate>
+                                </CollectionView>
+                                <Button Text="Send Files"
+                                        Command="{Binding FileSelectorVM.SendFilesCommand}"
+                                        IsVisible="{Binding FileSelectorVM.IsButtonVisible}"
+                                        BackgroundColor="#4C3B8A">
+                                        
+                                        <Button.Shadow>
+                                            <Shadow Brush="Black" 
+                                                    Radius="10" 
+                                                    Opacity="0.5" 
+                                                    Offset="2,2"/>
+                                        </Button.Shadow>
+                                </Button>
+                            </VerticalStackLayout>
+                            
+                        </Frame>
 
-                <!-- Add New Files -->
-                <Frame Padding="20" CornerRadius="10" BackgroundColor="White">
-                    <VerticalStackLayout Spacing="10">
-                        <Label Text="Add New Files" 
-                               FontAttributes="Bold"
-                               FontSize="16"/>
-                        <Button Text="Upload" 
-                                BackgroundColor="#4C3B8A" 
-                                TextColor="White"
-                                Command="{Binding FileVM.AddFilesCommand}"/>
+                         <Frame Padding="20" CornerRadius="10" BackgroundColor="White">
+                            <VerticalStackLayout Spacing="10">
+                                    <Label Text="Receiving Queue" 
+                                           FontAttributes="Bold"
+                                           FontSize="16"
+                                           VerticalTextAlignment="Center"
+                                           Margin="0,7,0,0"
+                                           />
+                                    
+                                    <BoxView Color="#4C3B8A"
+                                             HeightRequest="2"
+                                             IsVisible="{Binding DirectoryVM.IsRetrieveButtonVisible}"
+                                             Margin="0,3,0,0"/>
+                                             
+                                    <CollectionView ItemsSource="{Binding DirectoryVM.QueuedFiles}">
+                                        <CollectionView.ItemTemplate>
+                                            <DataTemplate x:DataType="{x:Type directoryNav:ShownFiles}">
+                                                <Grid ColumnDefinitions="*, Auto">
+                                                    
+                                                    <Label Text="{Binding fileName}" 
+                                                           VerticalOptions="Center"
+                                                           Grid.Column="0"/> 
+                                                
+                                                    <Button Text="X"
+                                                            Style="{x:Null}"
+                                                            BackgroundColor="Transparent"
+                                                            TextColor="Black"
+                                                            BorderWidth="0"
+                                                            CornerRadius="0"
+                                                            Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.DirectoryVM.removeFilesCommand}"
+                                                            CommandParameter="{Binding .}"
+                                                            Grid.Column="1"/>
+                                                </Grid>
+                                            </DataTemplate>
+                                        </CollectionView.ItemTemplate>
+                                    </CollectionView>
+                                <Button Text="Retrieve Files"
+                                        Command="{Binding DirectoryVM.retrieveFiles}"
+                                        IsVisible="{Binding DirectoryVM.IsRetrieveButtonVisible}"
+                                        BackgroundColor="#4C3B8A">
+                                    <Button.Shadow>
+                                        <Shadow Brush="Black" 
+                                                Radius="10" 
+                                                Opacity="0.5" 
+                                                Offset="2,2"/>
+                                    </Button.Shadow>
+                                </Button>
+                            </VerticalStackLayout>
+                        </Frame>
+
                     </VerticalStackLayout>
                     
-                </Frame>
-                
-                <Frame Padding="20" CornerRadius="10" BackgroundColor="White">
-                    <VerticalStackLayout Spacing="10">
-                            <Label Text="Queued Files" 
-                                   FontAttributes="Bold"
-                                   FontSize="16"
-                                   VerticalTextAlignment="Center"/>
-                            
-                        <CollectionView ItemsSource="{Binding FileVM.Files}">
-                            <!-- 
-                            This will show text saying that the user hasnt committed any files yet 
-                            Right now it glitches the UI so will come back to it 
-                            <CollectionView.EmptyView>
-                                <Label Text="No Files"></Label>
-                            </CollectionView.EmptyView>
-                            -->
-                            <CollectionView.ItemTemplate>
-                                <DataTemplate x:DataType="{x:Type fileselector:FilesSelected}">
-                                    <Grid ColumnDefinitions="*, Auto">
-                                        
-                                            
-                                            <Label Text="{Binding fileName}" 
-                                                   VerticalOptions="Center"
-                                                   Grid.Column="0"/> 
-                                        
-                                            <Button Text="X"
-                                                    Style="{x:Null}"
-                                                    BackgroundColor="Transparent"
-                                                    TextColor="Black"
-                                                    BorderWidth="0"
-                                                    CornerRadius="0"
-                                                    Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.FileVM.RemoveFilesCommand}"
-                                                    CommandParameter="{Binding .}"
-                                                    Grid.Column="1"/>
-                                        
-                                    </Grid>
-                                </DataTemplate>
-                            </CollectionView.ItemTemplate>
-                        </CollectionView>
-                        <!-- Command="{Binding Function for sending files} -->
-                        <Button Text="Send Files"
-                                Command="{Binding FileVM.SendFilesCommand}"
-                                IsVisible="{Binding FileVM.IsButtonVisible}"
-                                ></Button>
-                        
-                    </VerticalStackLayout>
-                </Frame>
+                    <BoxView BackgroundColor="Transparent"
+                             Grid.Row="1"/>
 
-                <!-- Storage Info -->
-                <Frame Padding="20" CornerRadius="10" BackgroundColor="White">
-                    <VerticalStackLayout Spacing="10">
-                        <Label Text="Your Storage"
-                               FontAttributes="Bold" 
-                               FontSize="16"/>
-                        <Label Text="-- GB used of -- GB" FontSize="12"/>
-                        <ProgressBar Progress="0" />
-                        <Label Text="Storage information not available"
-                               FontSize="12"
-                               HorizontalOptions="End"/>
-                    </VerticalStackLayout>
-                </Frame>
-
-                <!-- Favourites -->
-                <Frame Padding="20" CornerRadius="10" BackgroundColor="White">
-                    <VerticalStackLayout Spacing="10">
-                        <Label Text="Favourites"
-                               FontAttributes="Bold"
-                               FontSize="16"/>
-                        <!-- Just a couple static placeholders -->
-                        <Label Text="May_26th_Photo (JPEG)" FontSize="12"/>
-                        <Label Text="School_Project (Word Doc)" FontSize="12"/>
-                    </VerticalStackLayout>
-                </Frame>
-            </VerticalStackLayout>
+                    <!-- Storage Info -->
+                    <Frame Padding="20" CornerRadius="10" BackgroundColor="White" Grid.Row="2">
+                        <VerticalStackLayout Spacing="10">
+                            <Label Text="Your Storage"
+                                   FontAttributes="Bold" 
+                                   FontSize="16"/>
+                            <Label Text="-- GB used of -- GB" FontSize="12"/>
+                            <ProgressBar Progress="0" />
+                            <Label Text="Storage information not available"
+                                   FontSize="12"
+                                   HorizontalOptions="End"/>
+                        </VerticalStackLayout>
+                    </Frame>
+                    
+                </Grid>
         </ScrollView>
     </Grid>
 </ContentPage>


### PR DESCRIPTION
- Now the search bar and directory title do not scroll with the files
- Files scroll under the directory header
- For the files to wrap I had to limit the columns to 5 but this can be adjusted if we find a better way
- The file text now truncates when it is long enough to run into another file