### PR TITLE
Stephan tests

### DIFF
--- a/FileLink.Client/Protocol/PacketFactoryTestsNUnit.cs
+++ b/FileLink.Client/Protocol/PacketFactoryTestsNUnit.cs
@@ -1,0 +1,8 @@
+﻿namespace FileLink.Client.Protocol;
+
+public class PacketFactoryTestsNUnit
+{
+    
+    
+    
+}

--- a/FileLink.Client/Protocol/PacketSerializer.cs
+++ b/FileLink.Client/Protocol/PacketSerializer.cs
@@ -213,6 +213,7 @@ namespace FileLink.Client.Protocol
                     {
                         packet.Payload = tempData; // if the packet is never encrypted to begin with, it will be stored in packet.Payload
                     }
+                    
                 }
 
                 return packet;

--- a/FileLink.Client/Protocol/PacketSerializer.cs
+++ b/FileLink.Client/Protocol/PacketSerializer.cs
@@ -71,10 +71,7 @@ namespace FileLink.Client.Protocol
                 {
                     // Add packet type differentiator 
 
-                    if (packet.CommandCode == Commands.CommandCode.FILE_UPLOAD_CHUNK_REQUEST || packet.CommandCode == Commands.CommandCode.FILE_UPLOAD_CHUNK_RESPONSE || 
-                        packet.CommandCode == Commands.CommandCode.FILE_DOWNLOAD_CHUNK_REQUEST || packet.CommandCode == Commands.CommandCode.FILE_DOWNLOAD_CHUNK_RESPONSE ||
-                        packet.CommandCode == Commands.CommandCode.FILE_UPLOAD_INIT_REQUEST || packet.CommandCode == Commands.CommandCode.FILE_UPLOAD_INIT_RESPONSE || 
-                        packet.CommandCode == Commands.CommandCode.FILE_DOWNLOAD_INIT_REQUEST || packet.CommandCode == Commands.CommandCode.FILE_DOWNLOAD_INIT_RESPONSE) 
+                    if (packet.CommandCode == Commands.CommandCode.FILE_UPLOAD_CHUNK_REQUEST) 
                     {
                         
                         packet.EncryptedPayload = EncryptPayload(packet.Payload); // Encrypting packet payload yo
@@ -82,22 +79,11 @@ namespace FileLink.Client.Protocol
                         writer.Write(packet.EncryptedPayload); // Writing the encrypted payload 
                         
                     }
-                    else if(packet.CommandCode == Commands.CommandCode.LOGIN_REQUEST || packet.CommandCode == Commands.CommandCode.LOGIN_RESPONSE ||
-                            packet.CommandCode == Commands.CommandCode.LOGOUT_RESPONSE || packet.CommandCode == Commands.CommandCode.LOGOUT_REQUEST ||
-                            packet.CommandCode == Commands.CommandCode.FILE_LIST_RESPONSE || packet.CommandCode == Commands.CommandCode.FILE_LIST_REQUEST ||
-                            packet.CommandCode == Commands.CommandCode.FILE_DELETE_RESPONSE || packet.CommandCode == Commands.CommandCode.FILE_DELETE_REQUEST || 
-                            packet.CommandCode == Commands.CommandCode.CREATE_ACCOUNT_REQUEST || packet.CommandCode == Commands.CommandCode.CREATE_ACCOUNT_RESPONSE ||
-                            packet.CommandCode == Commands.CommandCode.FILE_UPLOAD_COMPLETE_REQUEST || packet.CommandCode == Commands.CommandCode.FILE_UPLOAD_COMPLETE_RESPONSE ||
-                            packet.CommandCode == Commands.CommandCode.FILE_DOWNLOAD_COMPLETE_RESPONSE || packet.CommandCode == Commands.CommandCode.FILE_DOWNLOAD_COMPLETE_REQUEST ||
-                            packet.CommandCode == Commands.CommandCode.ERROR || packet.CommandCode == Commands.CommandCode.SUCCESS)
+                    else
                     {
                         writer.Write(packet.Payload.Length);
                         writer.Write(packet.Payload);
                         
-                    }
-                    else
-                    {
-                        writer.Write(0);
                     }
 
                 }
@@ -192,15 +178,7 @@ namespace FileLink.Client.Protocol
                 int payloadLength = reader.ReadInt32();
                 if (payloadLength > 0)
                 {
-                    bool encryptedCommands =
-                        packet.CommandCode == Commands.CommandCode.FILE_UPLOAD_CHUNK_REQUEST ||
-                        packet.CommandCode == Commands.CommandCode.FILE_UPLOAD_CHUNK_RESPONSE ||
-                        packet.CommandCode == Commands.CommandCode.FILE_DOWNLOAD_CHUNK_REQUEST ||
-                        packet.CommandCode == Commands.CommandCode.FILE_DOWNLOAD_CHUNK_RESPONSE ||
-                        packet.CommandCode == Commands.CommandCode.FILE_UPLOAD_INIT_REQUEST ||
-                        packet.CommandCode == Commands.CommandCode.FILE_UPLOAD_INIT_RESPONSE ||
-                        packet.CommandCode == Commands.CommandCode.FILE_DOWNLOAD_INIT_REQUEST ||
-                        packet.CommandCode == Commands.CommandCode.FILE_DOWNLOAD_INIT_RESPONSE;
+                    bool encryptedCommands = packet.CommandCode == Commands.CommandCode.FILE_UPLOAD_CHUNK_REQUEST;
                     
                     byte[] tempData = reader.ReadBytes(payloadLength);
                     

--- a/FileLink.Client/Protocol/PacketSerializerTests.cs
+++ b/FileLink.Client/Protocol/PacketSerializerTests.cs
@@ -1,0 +1,331 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+
+namespace FileLink.Client.Protocol;
+
+[TestFixture]
+public class PacketSerializerTests
+{
+    private PacketSerializer _serializer;
+
+    [SetUp]
+    public void Setup()
+    {
+        _serializer = new PacketSerializer();
+    }
+
+    [Test]
+    public void Serialize_Deserialize_Packet_Returns_Identical_CommandCode()
+    {
+
+        var packet = new Packet()
+        {
+            CommandCode = 1,
+            PacketId = Guid.NewGuid(),
+            UserId = "TestUser1",
+            Timestamp = DateTime.UtcNow,
+            Metadata = new Dictionary<string, string>{{"Key1", "Value1"}, {"Key2", "Value2"}},
+            Payload = Encoding.UTF8.GetBytes("TestPayload")
+
+        };
+        
+        var serialized = _serializer.Serialize(packet);
+        var deserializePacket = _serializer.Deserialize(serialized);
+        
+        Assert.That(packet.CommandCode, Is.EqualTo(deserializePacket.CommandCode));
+
+    }
+    
+    [Test]
+    public void Serialize_Deserialize_Packet_Returns_Identical_PacketId()
+    {
+
+        var packet = new Packet()
+        {
+            CommandCode = 1,
+            PacketId = Guid.NewGuid(),
+            UserId = "TestUser1",
+            Timestamp = DateTime.UtcNow,
+            Metadata = new Dictionary<string, string>{{"Key1", "Value1"}, {"Key2", "Value2"}},
+            Payload = Encoding.UTF8.GetBytes("TestPayload")
+
+        };
+        
+        var serialized = _serializer.Serialize(packet);
+        var deserializePacket = _serializer.Deserialize(serialized);
+        
+        Assert.That(packet.PacketId, Is.EqualTo(deserializePacket.PacketId));
+
+    }
+    
+    [Test]
+    public void Serialize_Deserialize_Packet_Returns_Identical_UserId()
+    {
+
+        var packet = new Packet()
+        {
+            CommandCode = 1,
+            PacketId = Guid.NewGuid(),
+            UserId = "TestUser1",
+            Timestamp = DateTime.UtcNow,
+            Metadata = new Dictionary<string, string>{{"Key1", "Value1"}, {"Key2", "Value2"}},
+            Payload = Encoding.UTF8.GetBytes("TestPayload")
+
+        };
+        
+        var serialized = _serializer.Serialize(packet);
+        var deserializePacket = _serializer.Deserialize(serialized);
+        
+        Assert.That(packet.UserId, Is.EqualTo(deserializePacket.UserId));
+
+    }
+    
+    [Test]
+    public void Serialize_Deserialize_Packet_Returns_Identical_Timestamp()
+    {
+
+        var packet = new Packet()
+        {
+            CommandCode = 1,
+            PacketId = Guid.NewGuid(),
+            UserId = "TestUser1",
+            Timestamp = DateTime.UtcNow,
+            Metadata = new Dictionary<string, string>{{"Key1", "Value1"}, {"Key2", "Value2"}},
+            Payload = Encoding.UTF8.GetBytes("TestPayload")
+
+        };
+        
+        var serialized = _serializer.Serialize(packet);
+        var deserializePacket = _serializer.Deserialize(serialized);
+        
+        Assert.That(packet.Timestamp.Ticks, Is.EqualTo(deserializePacket.Timestamp.Ticks));
+
+    }
+    
+    [Test]
+    public void Serialize_Deserialize_Packet_Returns_Identical_Metadata()
+    {
+
+        var packet = new Packet()
+        {
+            CommandCode = 1,
+            PacketId = Guid.NewGuid(),
+            UserId = "TestUser1",
+            Timestamp = DateTime.UtcNow,
+            Metadata = new Dictionary<string, string>{{"Key1", "Value1"}, {"Key2", "Value2"}},
+            Payload = Encoding.UTF8.GetBytes("TestPayload")
+
+        };
+        
+        var serialized = _serializer.Serialize(packet);
+        var deserializePacket = _serializer.Deserialize(serialized);
+        
+        CollectionAssert.AreEqual(packet.Metadata, deserializePacket.Metadata);
+
+    }
+    
+    [Test]
+    public void Serialize_Deserialize_Packet_Returns_Identical_Payload()
+    {
+
+        var packet = new Packet()
+        {
+            CommandCode = 1,
+            PacketId = Guid.NewGuid(),
+            UserId = "TestUser1",
+            Timestamp = DateTime.UtcNow,
+            Metadata = new Dictionary<string, string>{{"Key1", "Value1"}, {"Key2", "Value2"}},
+            Payload = Encoding.UTF8.GetBytes("TestPayload")
+
+        };
+        
+        var serialized = _serializer.Serialize(packet);
+        var deserializePacket = _serializer.Deserialize(serialized);
+
+        if (deserializePacket.Payload != null)
+        {
+            CollectionAssert.AreEqual(packet.Payload, deserializePacket.Payload);
+        }
+
+    }
+
+    [Test]
+    public void Serialize_Empty_Metadata_Returns_Empty_Metadata()
+    {
+
+        var packet = new Packet
+        {
+            CommandCode = 2,
+            PacketId = Guid.NewGuid(),
+            UserId = "TestUser1",
+            Timestamp = DateTime.UtcNow,
+            Metadata = new Dictionary<string, string>(),
+            Payload = Encoding.UTF8.GetBytes("TestPayload")
+            
+        };
+        
+        var serialized = _serializer.Serialize(packet);
+        var deserializePacket = _serializer.Deserialize(serialized);
+        
+        Assert.That(deserializePacket.Metadata, Is.Empty);
+
+    }
+
+    [Test]
+    public void Serialize_Empty_Payload_Returns_Empty_Payload()
+    {
+        var packet = new Packet
+        {
+            CommandCode = 3,
+            PacketId = Guid.NewGuid(),
+            UserId = "TestUser1",
+            Timestamp = DateTime.UtcNow,
+            Metadata = new Dictionary<string, string>{{"Key", "Value"}},
+            Payload = null
+            
+        };
+        
+        var serialized = _serializer.Serialize(packet);
+        var deserializePacket = _serializer.Deserialize(serialized);
+        
+        Assert.That(deserializePacket.Payload, Is.Null);
+        
+    }
+
+    [Test]
+    public void Serialize_Encrypted_Payload_Should_Decrypt()
+    {
+
+        var packet = new Packet
+        {
+            CommandCode = Commands.CommandCode.FILE_UPLOAD_CHUNK_REQUEST,
+            PacketId = Guid.NewGuid(),
+            UserId = "EncryptedUser",
+            Timestamp = DateTime.UtcNow,
+            Metadata = new Dictionary<string, string> { { "EncKey", "EncValue" } },
+            Payload = Encoding.UTF8.GetBytes("SecretPayload")
+
+        };
+        
+        var serialized = _serializer.Serialize(packet);
+        var deserializePacket = _serializer.Deserialize(serialized);
+        
+        Assert.That(deserializePacket.EncryptedPayload, Is.Not.Null);
+        if (deserializePacket.Payload != null)
+        {
+            CollectionAssert.AreEqual(packet.Payload, deserializePacket.Payload);
+        }
+        
+    }
+
+    [Test]
+    public async Task Write_Read_Packet_From_Stream_Returns_Identical_Packet_CommandCode()
+    {
+        var packet = new Packet
+        {
+            CommandCode = 4,
+            PacketId = Guid.NewGuid(),
+            UserId = "StreamUser",
+            Timestamp = DateTime.UtcNow,
+            Metadata = new Dictionary<string, string>{{"Key1", "Value1"}, {"Key2", "Value2"}},
+            Payload = Encoding.UTF8.GetBytes("TestPayload")
+
+        };
+
+        using var ms = new MemoryStream();
+        await _serializer.WritePacketToStreamAsync(ms, packet, CancellationToken.None);
+        ms.Position = 0;
+        var deserializePacket = await _serializer.ReadPacketFromStreamAsync(ms, CancellationToken.None);
+        
+        Assert.That(packet.CommandCode, Is.EqualTo(deserializePacket.CommandCode));
+
+    }
+    
+    [Test]
+    public async Task Write_Read_Packet_From_Stream_Returns_Identical_Packet_PacketId()
+    {
+        var packet = new Packet
+        {
+            CommandCode = 4,
+            PacketId = Guid.NewGuid(),
+            UserId = "StreamUser",
+            Timestamp = DateTime.UtcNow,
+            Metadata = new Dictionary<string, string>{{"Key1", "Value1"}, {"Key2", "Value2"}},
+            Payload = Encoding.UTF8.GetBytes("TestPayload")
+
+        };
+
+        using var ms = new MemoryStream();
+        await _serializer.WritePacketToStreamAsync(ms, packet, CancellationToken.None);
+        ms.Position = 0;
+        var deserializePacket = await _serializer.ReadPacketFromStreamAsync(ms, CancellationToken.None);
+        
+        Assert.That(packet.PacketId, Is.EqualTo(deserializePacket.PacketId));
+
+    }
+    
+    [Test]
+    public async Task Write_Read_Packet_From_Stream_Returns_Identical_Packet_UserId()
+    {
+        var packet = new Packet
+        {
+            CommandCode = 4,
+            PacketId = Guid.NewGuid(),
+            UserId = "StreamUser",
+            Timestamp = DateTime.UtcNow,
+            Metadata = new Dictionary<string, string>{{"Key1", "Value1"}, {"Key2", "Value2"}},
+            Payload = Encoding.UTF8.GetBytes("TestPayload")
+
+        };
+
+        using var ms = new MemoryStream();
+        await _serializer.WritePacketToStreamAsync(ms, packet, CancellationToken.None);
+        ms.Position = 0;
+        var deserializePacket = await _serializer.ReadPacketFromStreamAsync(ms, CancellationToken.None);
+        
+        Assert.That(packet.UserId, Is.EqualTo(deserializePacket.UserId));
+
+    }
+    
+    [Test]
+    public async Task Write_Read_Packet_From_Stream_Returns_Identical_Packet_Payload()
+    {
+        var packet = new Packet
+        {
+            CommandCode = 4,
+            PacketId = Guid.NewGuid(),
+            UserId = "StreamUser",
+            Timestamp = DateTime.UtcNow,
+            Metadata = new Dictionary<string, string>{{"Key1", "Value1"}, {"Key2", "Value2"}},
+            Payload = Encoding.UTF8.GetBytes("TestPayload")
+
+        };
+
+        using var ms = new MemoryStream();
+        await _serializer.WritePacketToStreamAsync(ms, packet, CancellationToken.None);
+        ms.Position = 0;
+        var deserializePacket = await _serializer.ReadPacketFromStreamAsync(ms, CancellationToken.None);
+
+        if (deserializePacket.Payload != null)
+        {
+            CollectionAssert.AreEqual(packet.Payload, deserializePacket.Payload);
+        }
+
+    }
+
+    [Test]
+    public void Deserialize_Invalid_ProtocolVersion_Throws_Exception()
+    {
+        byte[] invalidData = new byte[] { 99, 0, 5, 3, 1 };
+        Assert.Throws<ProtocolException>(() => _serializer.Deserialize(invalidData));
+        
+    }
+
+
+}

--- a/FileLink.Client/Protocol/PacketSerializerTestsNUnit.cs
+++ b/FileLink.Client/Protocol/PacketSerializerTestsNUnit.cs
@@ -194,7 +194,7 @@ public class PacketSerializerTestsNUnit
     }
 
     [Test]
-    public void Serialize_Encrypted_Payload_Should_Decrypt()
+    public void Serialize_Encrypted_Payload_Should_Decrypt_File_Chunk_Request()
     {
 
         var packet = new Packet

--- a/FileLink.Client/Protocol/PacketSerializerTestsNUnit.cs
+++ b/FileLink.Client/Protocol/PacketSerializerTestsNUnit.cs
@@ -1,0 +1,326 @@
+﻿using System.Text;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+
+namespace FileLink.Client.Protocol;
+
+[TestFixture]
+public class PacketSerializerTestsNUnit 
+{
+    private PacketSerializer _serializer;
+
+    [SetUp]
+    public void Setup()
+    {
+        _serializer = new PacketSerializer();
+    }
+
+    [Test]
+    public void Serialize_Deserialize_Packet_Returns_Identical_CommandCode()
+    {
+
+        var packet = new Packet()
+        {
+            CommandCode = 1,
+            PacketId = Guid.NewGuid(),
+            UserId = "TestUser1",
+            Timestamp = DateTime.UtcNow,
+            Metadata = new Dictionary<string, string>{{"Key1", "Value1"}, {"Key2", "Value2"}},
+            Payload = Encoding.UTF8.GetBytes("TestPayload")
+
+        };
+        
+        var serialized = _serializer.Serialize(packet);
+        var deserializePacket = _serializer.Deserialize(serialized);
+        
+        Assert.That(packet.CommandCode, Is.EqualTo(deserializePacket.CommandCode));
+
+    }
+    
+    [Test]
+    public void Serialize_Deserialize_Packet_Returns_Identical_PacketId()
+    {
+
+        var packet = new Packet()
+        {
+            CommandCode = 1,
+            PacketId = Guid.NewGuid(),
+            UserId = "TestUser1",
+            Timestamp = DateTime.UtcNow,
+            Metadata = new Dictionary<string, string>{{"Key1", "Value1"}, {"Key2", "Value2"}},
+            Payload = Encoding.UTF8.GetBytes("TestPayload")
+
+        };
+        
+        var serialized = _serializer.Serialize(packet);
+        var deserializePacket = _serializer.Deserialize(serialized);
+        
+        Assert.That(packet.PacketId, Is.EqualTo(deserializePacket.PacketId));
+
+    }
+    
+    [Test]
+    public void Serialize_Deserialize_Packet_Returns_Identical_UserId()
+    {
+
+        var packet = new Packet()
+        {
+            CommandCode = 1,
+            PacketId = Guid.NewGuid(),
+            UserId = "TestUser1",
+            Timestamp = DateTime.UtcNow,
+            Metadata = new Dictionary<string, string>{{"Key1", "Value1"}, {"Key2", "Value2"}},
+            Payload = Encoding.UTF8.GetBytes("TestPayload")
+
+        };
+        
+        var serialized = _serializer.Serialize(packet);
+        var deserializePacket = _serializer.Deserialize(serialized);
+        
+        Assert.That(packet.UserId, Is.EqualTo(deserializePacket.UserId));
+
+    }
+    
+    [Test]
+    public void Serialize_Deserialize_Packet_Returns_Identical_Timestamp()
+    {
+
+        var packet = new Packet()
+        {
+            CommandCode = 1,
+            PacketId = Guid.NewGuid(),
+            UserId = "TestUser1",
+            Timestamp = DateTime.UtcNow,
+            Metadata = new Dictionary<string, string>{{"Key1", "Value1"}, {"Key2", "Value2"}},
+            Payload = Encoding.UTF8.GetBytes("TestPayload")
+
+        };
+        
+        var serialized = _serializer.Serialize(packet);
+        var deserializePacket = _serializer.Deserialize(serialized);
+        
+        Assert.That(packet.Timestamp.Ticks, Is.EqualTo(deserializePacket.Timestamp.Ticks));
+
+    }
+    
+    [Test]
+    public void Serialize_Deserialize_Packet_Returns_Identical_Metadata()
+    {
+
+        var packet = new Packet()
+        {
+            CommandCode = 1,
+            PacketId = Guid.NewGuid(),
+            UserId = "TestUser1",
+            Timestamp = DateTime.UtcNow,
+            Metadata = new Dictionary<string, string>{{"Key1", "Value1"}, {"Key2", "Value2"}},
+            Payload = Encoding.UTF8.GetBytes("TestPayload")
+
+        };
+        
+        var serialized = _serializer.Serialize(packet);
+        var deserializePacket = _serializer.Deserialize(serialized);
+        
+        CollectionAssert.AreEqual(packet.Metadata, deserializePacket.Metadata);
+
+    }
+    
+    [Test]
+    public void Serialize_Deserialize_Packet_Returns_Identical_Payload()
+    {
+
+        var packet = new Packet()
+        {
+            CommandCode = 1,
+            PacketId = Guid.NewGuid(),
+            UserId = "TestUser1",
+            Timestamp = DateTime.UtcNow,
+            Metadata = new Dictionary<string, string>{{"Key1", "Value1"}, {"Key2", "Value2"}},
+            Payload = Encoding.UTF8.GetBytes("TestPayload")
+
+        };
+        
+        var serialized = _serializer.Serialize(packet);
+        var deserializePacket = _serializer.Deserialize(serialized);
+
+        if (deserializePacket.Payload != null)
+        {
+            CollectionAssert.AreEqual(packet.Payload, deserializePacket.Payload);
+        }
+
+    }
+
+    [Test]
+    public void Serialize_Empty_Metadata_Returns_Empty_Metadata()
+    {
+
+        var packet = new Packet
+        {
+            CommandCode = 2,
+            PacketId = Guid.NewGuid(),
+            UserId = "TestUser1",
+            Timestamp = DateTime.UtcNow,
+            Metadata = new Dictionary<string, string>(),
+            Payload = Encoding.UTF8.GetBytes("TestPayload")
+            
+        };
+        
+        var serialized = _serializer.Serialize(packet);
+        var deserializePacket = _serializer.Deserialize(serialized);
+        
+        Assert.That(deserializePacket.Metadata, Is.Empty);
+
+    }
+
+    [Test]
+    public void Serialize_Empty_Payload_Returns_Empty_Payload()
+    {
+        var packet = new Packet
+        {
+            CommandCode = 3,
+            PacketId = Guid.NewGuid(),
+            UserId = "TestUser1",
+            Timestamp = DateTime.UtcNow,
+            Metadata = new Dictionary<string, string>{{"Key", "Value"}},
+            Payload = null
+            
+        };
+        
+        var serialized = _serializer.Serialize(packet);
+        var deserializePacket = _serializer.Deserialize(serialized);
+        
+        Assert.That(deserializePacket.Payload, Is.Null);
+        
+    }
+
+    [Test]
+    public void Serialize_Encrypted_Payload_Should_Decrypt()
+    {
+
+        var packet = new Packet
+        {
+            CommandCode = Commands.CommandCode.FILE_UPLOAD_CHUNK_REQUEST,
+            PacketId = Guid.NewGuid(),
+            UserId = "EncryptedUser",
+            Timestamp = DateTime.UtcNow,
+            Metadata = new Dictionary<string, string> { { "EncKey", "EncValue" } },
+            Payload = Encoding.UTF8.GetBytes("SecretPayload")
+
+        };
+        
+        var serialized = _serializer.Serialize(packet);
+        var deserializePacket = _serializer.Deserialize(serialized);
+        
+        Assert.That(deserializePacket.EncryptedPayload, Is.Not.Null);
+        if (deserializePacket.Payload != null)
+        {
+            CollectionAssert.AreEqual(packet.Payload, deserializePacket.Payload);
+        }
+        
+    }
+
+    [Test]
+    public async Task Write_Read_Packet_From_Stream_Returns_Identical_Packet_CommandCode()
+    {
+        var packet = new Packet
+        {
+            CommandCode = 4,
+            PacketId = Guid.NewGuid(),
+            UserId = "StreamUser",
+            Timestamp = DateTime.UtcNow,
+            Metadata = new Dictionary<string, string>{{"Key1", "Value1"}, {"Key2", "Value2"}},
+            Payload = Encoding.UTF8.GetBytes("TestPayload")
+
+        };
+
+        using var ms = new MemoryStream();
+        await _serializer.WritePacketToStreamAsync(ms, packet, CancellationToken.None);
+        ms.Position = 0;
+        var deserializePacket = await _serializer.ReadPacketFromStreamAsync(ms, CancellationToken.None);
+        
+        Assert.That(packet.CommandCode, Is.EqualTo(deserializePacket.CommandCode));
+
+    }
+    
+    [Test]
+    public async Task Write_Read_Packet_From_Stream_Returns_Identical_Packet_PacketId()
+    {
+        var packet = new Packet
+        {
+            CommandCode = 4,
+            PacketId = Guid.NewGuid(),
+            UserId = "StreamUser",
+            Timestamp = DateTime.UtcNow,
+            Metadata = new Dictionary<string, string>{{"Key1", "Value1"}, {"Key2", "Value2"}},
+            Payload = Encoding.UTF8.GetBytes("TestPayload")
+
+        };
+
+        using var ms = new MemoryStream();
+        await _serializer.WritePacketToStreamAsync(ms, packet, CancellationToken.None);
+        ms.Position = 0;
+        var deserializePacket = await _serializer.ReadPacketFromStreamAsync(ms, CancellationToken.None);
+        
+        Assert.That(packet.PacketId, Is.EqualTo(deserializePacket.PacketId));
+
+    }
+    
+    [Test]
+    public async Task Write_Read_Packet_From_Stream_Returns_Identical_Packet_UserId()
+    {
+        var packet = new Packet
+        {
+            CommandCode = 4,
+            PacketId = Guid.NewGuid(),
+            UserId = "StreamUser",
+            Timestamp = DateTime.UtcNow,
+            Metadata = new Dictionary<string, string>{{"Key1", "Value1"}, {"Key2", "Value2"}},
+            Payload = Encoding.UTF8.GetBytes("TestPayload")
+
+        };
+
+        using var ms = new MemoryStream();
+        await _serializer.WritePacketToStreamAsync(ms, packet, CancellationToken.None);
+        ms.Position = 0;
+        var deserializePacket = await _serializer.ReadPacketFromStreamAsync(ms, CancellationToken.None);
+        
+        Assert.That(packet.UserId, Is.EqualTo(deserializePacket.UserId));
+
+    }
+    
+    [Test]
+    public async Task Write_Read_Packet_From_Stream_Returns_Identical_Packet_Payload()
+    {
+        var packet = new Packet
+        {
+            CommandCode = 4,
+            PacketId = Guid.NewGuid(),
+            UserId = "StreamUser",
+            Timestamp = DateTime.UtcNow,
+            Metadata = new Dictionary<string, string>{{"Key1", "Value1"}, {"Key2", "Value2"}},
+            Payload = Encoding.UTF8.GetBytes("TestPayload")
+
+        };
+
+        using var ms = new MemoryStream();
+        await _serializer.WritePacketToStreamAsync(ms, packet, CancellationToken.None);
+        ms.Position = 0;
+        var deserializePacket = await _serializer.ReadPacketFromStreamAsync(ms, CancellationToken.None);
+
+        if (deserializePacket.Payload != null)
+        {
+            CollectionAssert.AreEqual(packet.Payload, deserializePacket.Payload);
+        }
+
+    }
+
+    [Test]
+    public void Deserialize_Invalid_ProtocolVersion_Throws_Exception()
+    {
+        byte[] invalidData = new byte[] { 99, 0, 5, 3, 1 };
+        Assert.Throws<ProtocolException>(() => _serializer.Deserialize(invalidData));
+        
+    }
+
+
+}

--- a/FileLink.TestSuite/UnitTests/ClientUnitTests/PacketSerializerTestsNUnit.cs
+++ b/FileLink.TestSuite/UnitTests/ClientUnitTests/PacketSerializerTestsNUnit.cs
@@ -1,8 +1,9 @@
 ﻿using System.Text;
+using FileLink.Client.Protocol;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
 
-namespace FileLink.Client.Protocol;
+namespace FileLink.TestSuite.UnitTests.ClientUnitTests;
 
 [TestFixture]
 public class PacketSerializerTestsNUnit 
@@ -33,7 +34,7 @@ public class PacketSerializerTestsNUnit
         var serialized = _serializer.Serialize(packet);
         var deserializePacket = _serializer.Deserialize(serialized);
         
-        Assert.That(packet.CommandCode, Is.EqualTo(deserializePacket.CommandCode));
+        NUnit.Framework.Assert.That(packet.CommandCode, Is.EqualTo(deserializePacket.CommandCode));
 
     }
     
@@ -55,7 +56,7 @@ public class PacketSerializerTestsNUnit
         var serialized = _serializer.Serialize(packet);
         var deserializePacket = _serializer.Deserialize(serialized);
         
-        Assert.That(packet.PacketId, Is.EqualTo(deserializePacket.PacketId));
+        NUnit.Framework.Assert.That(packet.PacketId, Is.EqualTo(deserializePacket.PacketId));
 
     }
     
@@ -77,7 +78,7 @@ public class PacketSerializerTestsNUnit
         var serialized = _serializer.Serialize(packet);
         var deserializePacket = _serializer.Deserialize(serialized);
         
-        Assert.That(packet.UserId, Is.EqualTo(deserializePacket.UserId));
+        NUnit.Framework.Assert.That(packet.UserId, Is.EqualTo(deserializePacket.UserId));
 
     }
     
@@ -99,7 +100,7 @@ public class PacketSerializerTestsNUnit
         var serialized = _serializer.Serialize(packet);
         var deserializePacket = _serializer.Deserialize(serialized);
         
-        Assert.That(packet.Timestamp.Ticks, Is.EqualTo(deserializePacket.Timestamp.Ticks));
+        NUnit.Framework.Assert.That(packet.Timestamp.Ticks, Is.EqualTo(deserializePacket.Timestamp.Ticks));
 
     }
     
@@ -121,7 +122,7 @@ public class PacketSerializerTestsNUnit
         var serialized = _serializer.Serialize(packet);
         var deserializePacket = _serializer.Deserialize(serialized);
         
-        CollectionAssert.AreEqual(packet.Metadata, deserializePacket.Metadata);
+        NUnit.Framework.Legacy.CollectionAssert.AreEqual(packet.Metadata, deserializePacket.Metadata);
 
     }
     
@@ -145,7 +146,7 @@ public class PacketSerializerTestsNUnit
 
         if (deserializePacket.Payload != null)
         {
-            CollectionAssert.AreEqual(packet.Payload, deserializePacket.Payload);
+            NUnit.Framework.Legacy.CollectionAssert.AreEqual(packet.Payload, deserializePacket.Payload);
         }
 
     }
@@ -168,7 +169,7 @@ public class PacketSerializerTestsNUnit
         var serialized = _serializer.Serialize(packet);
         var deserializePacket = _serializer.Deserialize(serialized);
         
-        Assert.That(deserializePacket.Metadata, Is.Empty);
+        NUnit.Framework.Assert.That(deserializePacket.Metadata, Is.Empty);
 
     }
 
@@ -189,7 +190,7 @@ public class PacketSerializerTestsNUnit
         var serialized = _serializer.Serialize(packet);
         var deserializePacket = _serializer.Deserialize(serialized);
         
-        Assert.That(deserializePacket.Payload, Is.Null);
+        NUnit.Framework.Assert.That(deserializePacket.Payload, Is.Null);
         
     }
 
@@ -211,10 +212,10 @@ public class PacketSerializerTestsNUnit
         var serialized = _serializer.Serialize(packet);
         var deserializePacket = _serializer.Deserialize(serialized);
         
-        Assert.That(deserializePacket.EncryptedPayload, Is.Not.Null);
+        NUnit.Framework.Assert.That(deserializePacket.EncryptedPayload, Is.Not.Null);
         if (deserializePacket.Payload != null)
         {
-            CollectionAssert.AreEqual(packet.Payload, deserializePacket.Payload);
+            NUnit.Framework.Legacy.CollectionAssert.AreEqual(packet.Payload, deserializePacket.Payload);
         }
         
     }
@@ -238,7 +239,7 @@ public class PacketSerializerTestsNUnit
         ms.Position = 0;
         var deserializePacket = await _serializer.ReadPacketFromStreamAsync(ms, CancellationToken.None);
         
-        Assert.That(packet.CommandCode, Is.EqualTo(deserializePacket.CommandCode));
+        NUnit.Framework.Assert.That(packet.CommandCode, Is.EqualTo(deserializePacket.CommandCode));
 
     }
     
@@ -261,7 +262,7 @@ public class PacketSerializerTestsNUnit
         ms.Position = 0;
         var deserializePacket = await _serializer.ReadPacketFromStreamAsync(ms, CancellationToken.None);
         
-        Assert.That(packet.PacketId, Is.EqualTo(deserializePacket.PacketId));
+        NUnit.Framework.Assert.That(packet.PacketId, Is.EqualTo(deserializePacket.PacketId));
 
     }
     
@@ -284,7 +285,7 @@ public class PacketSerializerTestsNUnit
         ms.Position = 0;
         var deserializePacket = await _serializer.ReadPacketFromStreamAsync(ms, CancellationToken.None);
         
-        Assert.That(packet.UserId, Is.EqualTo(deserializePacket.UserId));
+        NUnit.Framework.Assert.That(packet.UserId, Is.EqualTo(deserializePacket.UserId));
 
     }
     
@@ -309,7 +310,7 @@ public class PacketSerializerTestsNUnit
 
         if (deserializePacket.Payload != null)
         {
-            CollectionAssert.AreEqual(packet.Payload, deserializePacket.Payload);
+            NUnit.Framework.Legacy.CollectionAssert.AreEqual(packet.Payload, deserializePacket.Payload);
         }
 
     }
@@ -318,7 +319,7 @@ public class PacketSerializerTestsNUnit
     public void Deserialize_Invalid_ProtocolVersion_Throws_Exception()
     {
         byte[] invalidData = new byte[] { 99, 0, 5, 3, 1 };
-        Assert.Throws<ProtocolException>(() => _serializer.Deserialize(invalidData));
+        NUnit.Framework.Assert.Throws<ProtocolException>(() => _serializer.Deserialize(invalidData));
         
     }
 


### PR DESCRIPTION
EncryptPayload was encrypting using the wrong packet commands (encrypted metadata).
Unit tests for the PacketSerializer.cs class were added. 